### PR TITLE
Merge Changes

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
@@ -167,9 +167,9 @@ public class ChallengeLogic {
             case '-':
                 return amount - inc * timesCompleted; // Why?
             case '*':
-                return amount * inc * timesCompleted; // Oh, my god! Just do the time m8!
+                return amount * Math.pow(inc, timesCompleted); // Oh, my god! Just do the time m8!
             case '/':
-                return amount / (inc * timesCompleted); // Yay! Free stuff!!!
+                return amount / Math.pow(inc, timesCompleted); // Yay! Free stuff!!!
         }
         return amount;
     }


### PR DESCRIPTION
The * operator will now double the requirements for a challenge after each completion (or triple, quadruple, etc based on the increment).
Ex: 4:16;*2 would require 16, 32, 64, 128, 256, 512, 1024, 2048 cobblestone for each completion.

Also the '/' operator will no longer divide by 0, but remains just as useless.